### PR TITLE
Stop process if no post id was found

### DIFF
--- a/includes/MergeTags/Deprecated.php
+++ b/includes/MergeTags/Deprecated.php
@@ -29,7 +29,10 @@ final class NF_MergeTags_Deprecated extends NF_Abstracts_MergeTags
     {
         global $post;
 
-        $this->setup_post_meta( $this->post_id() );
+        $post_id = $this->post_id();
+        if ( ! empty( $post_id ) ) {
+            $this->setup_post_meta( $post_id );
+        }
     }
 
     protected function post_id()


### PR DESCRIPTION
The setup_post_meta call is executing a unneeded query even if the post_id is not found. This returns early if no point was found.